### PR TITLE
Remove generated name / type / receiver constants

### DIFF
--- a/dihedral_test.go
+++ b/dihedral_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExampleInjection(t *testing.T) {
-	component := digen.NewServiceComponent(&dbstore.DBProviderModule{
+	component := digen.NewDihedralServiceComponent(&dbstore.DBProviderModule{
 		Prefix: "Hello",
 	})
 	service, err := component.GetService()

--- a/gen/assignment.go
+++ b/gen/assignment.go
@@ -27,39 +27,48 @@ type Assignment interface {
 }
 
 type factoryAssignment struct {
-	typeName *types.Named
-	hasError bool
+	componentReceiverName string
+	typeName              *types.Named
 }
 
 // NewFactoryAssignment returns a factory-method based assignment
-func NewFactoryAssignment(typeName *types.Named) Assignment {
+func NewFactoryAssignment(
+	componentReceiverName string,
+	typeName *types.Named,
+) Assignment {
 	return &factoryAssignment{
-		typeName: typeName,
+		componentReceiverName: componentReceiverName,
+		typeName:              typeName,
 	}
 }
 
 func (f *factoryAssignment) GetSourceAssignment() string {
-	return FactoryName(f.typeName) + "(" + componentName + ")"
+	return FactoryName(f.typeName) + "(" + f.componentReceiverName + ")"
 }
 
 type providerAssignment struct {
-	typeName *types.Named
-	hasError bool
+	componentReceiverName string
+	typeName              *types.Named
 }
 
 // NewProviderAssignment returns a component provided assignment
-func NewProviderAssignment(typeName *types.Named) Assignment {
+func NewProviderAssignment(
+	componentReceiverName string,
+	typeName *types.Named,
+) Assignment {
 	return &providerAssignment{
-		typeName: typeName,
+		componentReceiverName: componentReceiverName,
+		typeName:              typeName,
 	}
 }
 
 func (p *providerAssignment) GetSourceAssignment() string {
-	return componentName + "." + ProviderName(p.typeName) + "()"
+	return p.componentReceiverName + "." + ProviderName(p.typeName) + "()"
 }
 
 // AssignmentForFieldType returns an assignment for the given field type
 func AssignmentForFieldType(
+	componentReceiverName string,
 	rawFieldType types.Type,
 	providers map[string]resolver.ResolvedType,
 	bindings map[string]*structs.Struct,
@@ -84,11 +93,11 @@ func AssignmentForFieldType(
 		typedProvider, ok := provider.(*resolver.ModuleResolvedType)
 		if ok {
 			fieldName = typedProvider.Name
-			return NewProviderAssignment(fieldName), nil
+			return NewProviderAssignment(componentReceiverName, fieldName), nil
 		}
 
 		return nil, fmt.Errorf("Unknown provider type %+v", provider)
 	}
 
-	return NewFactoryAssignment(fieldName), nil
+	return NewFactoryAssignment(componentReceiverName, fieldName), nil
 }

--- a/internal/example/bindings/digen/component.go
+++ b/internal/example/bindings/digen/component.go
@@ -7,29 +7,29 @@ import (
 	di_import_2 "github.com/dimes/dihedral/internal/example/dbstore"
 )
 
-type GeneratedComponent struct {
+type DihedralServiceComponent struct {
 	github_com_dimes_dihedral_internal_example_bindings_ServiceModule   *di_import_1.ServiceModule
 	github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule *di_import_2.DBProviderModule
 }
 
-func NewServiceComponent(
+func NewDihedralServiceComponent(
 	github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule *di_import_2.DBProviderModule,
-) *GeneratedComponent {
-	return &GeneratedComponent{
+) *DihedralServiceComponent {
+	return &DihedralServiceComponent{
 		github_com_dimes_dihedral_internal_example_bindings_ServiceModule:   &di_import_1.ServiceModule{},
 		github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule: github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule,
 	}
 }
-func (generatedComponent *GeneratedComponent) GetService() (*di_import_3.Service, error) {
-	obj, err := factory_github_com_dimes_dihedral_internal_example_Service(generatedComponent)
+func (d *DihedralServiceComponent) GetService() (*di_import_3.Service, error) {
+	obj, err := factory_github_com_dimes_dihedral_internal_example_Service(d)
 	if err != nil {
 		var zeroValue *di_import_3.Service
 		return zeroValue, err
 	}
 	return obj, nil
 }
-func (generatedComponent *GeneratedComponent) GetServiceTimeout() (di_import_3.ServiceTimeout, error) {
-	obj, err := generatedComponent.provides_github_com_dimes_dihedral_internal_example_ServiceTimeout()
+func (d *DihedralServiceComponent) GetServiceTimeout() (di_import_3.ServiceTimeout, error) {
+	obj, err := d.provides_github_com_dimes_dihedral_internal_example_ServiceTimeout()
 	if err != nil {
 		var zeroValue di_import_3.ServiceTimeout
 		return zeroValue, err

--- a/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_ServiceTimeout_Provider.go
+++ b/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_ServiceTimeout_Provider.go
@@ -3,7 +3,6 @@ package digen
 
 import target_pkg "github.com/dimes/dihedral/internal/example"
 
-func (generatedComponent *GeneratedComponent,
-) provides_github_com_dimes_dihedral_internal_example_ServiceTimeout() (target_pkg.ServiceTimeout, error) {
-	return generatedComponent.github_com_dimes_dihedral_internal_example_bindings_ServiceModule.ProvidesServiceTimeout()
+func (d *DihedralServiceComponent) provides_github_com_dimes_dihedral_internal_example_ServiceTimeout() (target_pkg.ServiceTimeout, error) {
+	return d.github_com_dimes_dihedral_internal_example_bindings_ServiceModule.ProvidesServiceTimeout()
 }

--- a/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_Service_Factory.go
+++ b/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_Service_Factory.go
@@ -3,15 +3,15 @@ package digen
 
 import target_pkg "github.com/dimes/dihedral/internal/example"
 
-func factory_github_com_dimes_dihedral_internal_example_Service(generatedComponent *GeneratedComponent) (*target_pkg.Service, error) {
+func factory_github_com_dimes_dihedral_internal_example_Service(d *DihedralServiceComponent) (*target_pkg.Service, error) {
 	target := &target_pkg.Service{}
-	ServiceTimeout, err := generatedComponent.provides_github_com_dimes_dihedral_internal_example_ServiceTimeout()
+	ServiceTimeout, err := d.provides_github_com_dimes_dihedral_internal_example_ServiceTimeout()
 	if err != nil {
 		var zeroValue *target_pkg.Service
 		return zeroValue, err
 	}
 	target.ServiceTimeout = ServiceTimeout
-	DBStore, err := factory_github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore(generatedComponent)
+	DBStore, err := factory_github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore(d)
 	if err != nil {
 		var zeroValue *target_pkg.Service
 		return zeroValue, err

--- a/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore_Factory.go
+++ b/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore_Factory.go
@@ -3,9 +3,9 @@ package digen
 
 import target_pkg "github.com/dimes/dihedral/internal/example/dbstore"
 
-func factory_github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore(generatedComponent *GeneratedComponent) (*target_pkg.MemoryDBStore, error) {
+func factory_github_com_dimes_dihedral_internal_example_dbstore_MemoryDBStore(d *DihedralServiceComponent) (*target_pkg.MemoryDBStore, error) {
 	target := &target_pkg.MemoryDBStore{}
-	Prefix, err := generatedComponent.provides_github_com_dimes_dihedral_internal_example_dbstore_Prefix()
+	Prefix, err := d.provides_github_com_dimes_dihedral_internal_example_dbstore_Prefix()
 	if err != nil {
 		var zeroValue *target_pkg.MemoryDBStore
 		return zeroValue, err

--- a/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_dbstore_Prefix_Provider.go
+++ b/internal/example/bindings/digen/github_com_dimes_dihedral_internal_example_dbstore_Prefix_Provider.go
@@ -3,7 +3,6 @@ package digen
 
 import target_pkg "github.com/dimes/dihedral/internal/example/dbstore"
 
-func (generatedComponent *GeneratedComponent,
-) provides_github_com_dimes_dihedral_internal_example_dbstore_Prefix() (target_pkg.Prefix, error) {
-	return generatedComponent.github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule.ProvidesPrefix(), nil
+func (d *DihedralServiceComponent) provides_github_com_dimes_dihedral_internal_example_dbstore_Prefix() (target_pkg.Prefix, error) {
+	return d.github_com_dimes_dihedral_internal_example_dbstore_DBProviderModule.ProvidesPrefix(), nil
 }

--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	component := digen.NewServiceComponent(&dbstore.DBProviderModule{
+	component := digen.NewDihedralServiceComponent(&dbstore.DBProviderModule{
 		Prefix: "Hello",
 	})
 


### PR DESCRIPTION
Removing constant names for the generated component types will help when generating subcomponents with different types. 