### PR TITLE
Fix receiver in providers

### DIFF
--- a/gen/provider.go
+++ b/gen/provider.go
@@ -41,7 +41,7 @@ func NewGeneratedProvider(
 	signature := resolvedType.Method.Type().(*types.Signature)
 	for i := 0; i < signature.Params().Len(); i++ {
 		param := signature.Params().At(i)
-		assignment, err := AssignmentForFieldType(generatedComponentType, param.Type(), providers, bindings)
+		assignment, err := AssignmentForFieldType(generatedComponentReceiver, param.Type(), providers, bindings)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error generating binding for %+v", resolvedType)
 		}


### PR DESCRIPTION
For some reason, the component type name was being passed into a provider assignment instead of the receiver name.

cc @dimes 